### PR TITLE
Add linter to project to help us catch some errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": ["eslint:recommended", "google"],
+  "rules": {
+    "no-multi-spaces": "off",
+    "require-jsdoc": "off",
+    "valid-jsdoc": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Ignore generated NPM files
+# These are sometimes included but not necessary for this project
+package-lock.json
+node_modules/
+
+# Ignore generated Maven build files
 target/
+
+# Ignore editor config
 .idea

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,11 @@
+{
+  "elements": [
+    "html5"
+  ],
+  "extends": [
+    "html-validate:recommended"
+  ],
+  "rules": {
+    "void-style": "off"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,22 @@
+{
+  "semi": false,
+  "overrides": [
+    {
+      "files": ["*.html"],
+      "options": {
+        "printWidth": 120,
+        "tabWidth": 2,
+        "singleQuote": false,
+        "useTabs": false
+      }
+    },
+    {
+      "files": ["*.css"],
+      "options": {
+        "tabWidth": 2,
+        "singleQuote": true,
+        "useTabs": false
+      }
+    }
+  ]
+}

--- a/makefile
+++ b/makefile
@@ -1,0 +1,21 @@
+CLANG_FORMAT=node_modules/clang-format/bin/linux_x64/clang-format --style=Google
+CSS_VALIDATOR=node_modules/css-validator/bin/css-validator
+ESLINT=node_modules/eslint/bin/eslint.js
+HTML_VALIDATE=node_modules/html-validate/bin/html-validate.js
+PRETTIER=node_modules/prettier/bin-prettier.js
+
+node_modules:
+	npm install clang-format prettier css-validator html-validate eslint eslint-config-google
+
+pretty: node_modules
+	$(PRETTIER) --write portfolio/src/main/webapp/*.{html,css}
+	find portfolio/src/main/java -iname *.java | xargs $(CLANG_FORMAT) -i
+	find portfolio/src/main/webapp -iname *.js | xargs $(CLANG_FORMAT) -i
+
+validate: node_modules
+	$(HTML_VALIDATE) portfolio/src/main/webapp/*.html
+	$(CSS_VALIDATOR) portfolio/src/main/webapp/*.css
+	$(ESLINT) portfolio/src/main/webapp/*.js
+
+package:
+	mvn package


### PR DESCRIPTION
Followed what another host did to add linters to their projects: https://github.com/brettallenyo/step2020/pull/1

I ran it and it caught some small issues. Let's create a PR to fix these linter issues as soon as possible. 

We can run these locally before we send out any PRs:
- `make pretty` to format code
- `make validate` to validate the code